### PR TITLE
Add ephemeral default to components and the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `Client.iter_commands`, `Client.iter_message_commands` and `Client.iter_slash_commands`.
+- Ephemeral default is now applicable at a client and component level with it defaulting to `None` on
+  components, this will propagate down from the client to the command being executed with each level
+  having the option to override its state or leave it as is.
+
+### Changed
+- SlashCommand's ephemeral default now defaults to `None` indicating that the parent entity's state should
+  be used.
 
 ### Removed
 - `tanjun.abc.ExecutableCommand.execute` and `check_context` as this doesn't work typing wise.

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -1876,18 +1876,21 @@ class BaseSlashCommand(ExecutableCommand[SlashContext], abc.ABC):
 
     @property
     @abc.abstractmethod
-    def defaults_to_ephemeral(self) -> bool:
-        """Whether calls to this command should default to ephemeral mode.
+    def defaults_to_ephemeral(self) -> typing.Optional[bool]:
+        """Whether contexts executed by this command should default to ephemeral responses.
 
-        This indicates whether calls to `SlashContext.respond`,
-        `SlashContext.create_initial_response` and `SlashContext.create_followup`
-        on context objects which are linked to this command should default to
-        ephemeral unless `flags` is explicitly passed.
+        This effects calls to `SlashContext.create_followup`,
+        `SlashContext.create_initial_response`, `SlashContext.defer` and
+        `SlashContext.respond` unless the `flags` field is provided for the
+        methods which support it.
 
         Returns
         -------
         bool
             Whether calls to this command should default to ephemeral mode.
+
+            If this is `None` then the default from the parent command(s),
+            component or client is used.
         """
 
     @property
@@ -2247,6 +2250,29 @@ class Component(abc.ABC):
         -------
         client : typing.Optional[Client]
             The client this component is bound to.
+        """
+
+    @property
+    @abc.abstractmethod
+    def defaults_to_ephemeral(self) -> typing.Optional[bool]:
+        """Whether slash contexts executed in this component should default to ephemeral responses.
+
+        This effects calls to `SlashContext.create_followup`,
+        `SlashContext.create_initial_response`, `SlashContext.defer` and
+        `SlashContext.respond` unless the `flags` field is provided for the
+        methods which support it.
+
+        Notes
+        -----
+        * This may be overridden by `BaseSlashCommand.defaults_to_ephemeral`.
+        * This only effects slash command execution.
+
+        Returns
+        -------
+        typing.Optional[bool]
+            Whether contexts executed in this component should default to ephemeral responses.
+
+            If this is `None` then the default from the parent client is used.
         """
 
     @property
@@ -2652,6 +2678,30 @@ class Client(abc.ABC):
         -------
         collections.abc.Collection[tanjun.traits.Component]
             Collection of the components this command client is using.
+        """
+
+    @property
+    @abc.abstractmethod
+    def defaults_to_ephemeral(self) -> bool:
+        """Whether slash contexts spawned by this client should default to ephemeral responses.
+
+        This effects calls to `SlashContext.create_followup`,
+        `SlashContext.create_initial_response`, `SlashContext.defer` and
+        `SlashContext.respond` unless the `flags` field is provided for the
+        methods which support it.
+
+        Notes
+        -----
+        * This may be overridden by `BaseSlashCommand.defaults_to_ephemeral`
+          and `Component.defaults_to_ephemeral`.
+        * This defaults to `False`.
+        * This only effects slash command execution.
+
+        Returns
+        -------
+        bool
+            Whether slash contexts executed in this component should default
+            to ephemeral responses.
         """
 
     @property

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -99,7 +99,9 @@ if typing.TYPE_CHECKING:
             command: typing.Optional[tanjun_abc.BaseSlashCommand] = None,
             component: typing.Optional[tanjun_abc.Component] = None,
             default_to_ephemeral: bool = False,
-            on_not_found: typing.Optional[typing.Callable[[context.SlashContext], None]] = None,
+            on_not_found: typing.Optional[
+                collections.Callable[[context.SlashContext], collections.Awaitable[None]]
+            ] = None,
         ) -> context.SlashContext:
             raise NotImplementedError
 
@@ -2178,7 +2180,7 @@ class Client(injecting.InjectorClient, tanjun_abc.Client):
 
         return hooks
 
-    async def _on_slash_not_found(self, ctx: tanjun_abc.SlashContext) -> None:
+    async def _on_slash_not_found(self, ctx: context.SlashContext) -> None:
         await self.dispatch_client_callback(ClientCallbackNames.SLASH_COMMAND_NOT_FOUND, ctx)
         if self._interaction_not_found and not ctx.has_responded:
             await ctx.create_initial_response(self._interaction_not_found)

--- a/tanjun/commands.py
+++ b/tanjun/commands.py
@@ -212,7 +212,7 @@ def slash_command_group(
     *,
     command_id: typing.Optional[hikari.SnowflakeishOr[hikari.Command]] = None,
     default_permission: bool = True,
-    default_to_ephemeral: bool = False,
+    default_to_ephemeral: typing.Optional[bool] = None,
     is_global: bool = True,
 ) -> SlashCommandGroup:
     """Create a slash command group.
@@ -265,9 +265,12 @@ def slash_command_group(
         Whether this command can be accessed without set permissions.
 
         Defaults to `True`, meaning that users can access the command by default.
-    default_to_ephemeral : bool
+    default_to_ephemeral : typing.Optional[bool]
         Whether this command's responses should default to ephemeral unless flags
-        are set to override this. This defaults to `False`.
+        are set to override this.
+
+        If this is left as `None` then the default set on the parent command(s),
+        component or client will be in effect.
     is_global : bool
         Whether this command is a global command. Defaults to `True`.
 
@@ -301,7 +304,7 @@ def as_slash_command(
     *,
     command_id: typing.Optional[hikari.SnowflakeishOr[hikari.Command]] = None,
     default_permission: bool = True,
-    default_to_ephemeral: bool = False,
+    default_to_ephemeral: typing.Optional[bool] = None,
     is_global: bool = True,
     sort_options: bool = True,
 ) -> collections.Callable[[CommandCallbackSigT], SlashCommand[CommandCallbackSigT]]:
@@ -347,9 +350,12 @@ def as_slash_command(
         Whether this command can be accessed without set permissions.
 
         Defaults to `True`, meaning that users can access the command by default.
-    default_to_ephemeral : bool
+    default_to_ephemeral : typing.Optional[bool]
         Whether this command's responses should default to ephemeral unless flags
-        are set to override this. This defaults to `False`.
+        are set to override this.
+
+        If this is left as `None` then the default set on the parent command(s),
+        component or client will be in effect.
     is_global : bool
         Whether this command is a global command. Defaults to `True`.
     sort_options : bool
@@ -790,7 +796,7 @@ class BaseSlashCommand(PartialCommand[abc.SlashContext], abc.BaseSlashCommand):
         /,
         *,
         command_id: typing.Optional[hikari.SnowflakeishOr[hikari.Command]] = None,
-        default_to_ephemeral: bool = False,
+        default_to_ephemeral: typing.Optional[bool] = None,
         is_global: bool = True,
         checks: typing.Optional[collections.Iterable[abc.CheckSig]] = None,
         hooks: typing.Optional[abc.SlashHooks] = None,
@@ -822,7 +828,7 @@ class BaseSlashCommand(PartialCommand[abc.SlashContext], abc.BaseSlashCommand):
         self._parent: typing.Optional[abc.SlashCommandGroup] = None
 
     @property
-    def defaults_to_ephemeral(self) -> bool:
+    def defaults_to_ephemeral(self) -> typing.Optional[bool]:
         # <<inherited docstring from tanjun.abc.BaseSlashCommand>>.
         return self._defaults_to_ephemeral
 
@@ -863,6 +869,11 @@ class BaseSlashCommand(PartialCommand[abc.SlashContext], abc.BaseSlashCommand):
         ----------
         command : hikari.Command
             object of the global command this should be tracking.
+
+        Returns
+        -------
+        SelfT
+            This command instance for chaining.
         """
         if not isinstance(command, hikari.Command):
             warnings.warn(
@@ -875,14 +886,23 @@ class BaseSlashCommand(PartialCommand[abc.SlashContext], abc.BaseSlashCommand):
         self._command_id = hikari.Snowflake(command)
         return self
 
-    def set_ephemeral_default(self: _BaseSlashCommandT, state: bool, /) -> _BaseSlashCommandT:
+    def set_ephemeral_default(self: _BaseSlashCommandT, state: typing.Optional[bool], /) -> _BaseSlashCommandT:
         """Set whether this command's responses should default to ephemeral.
 
         Parameters
         ----------
-        bool
+        typing.Optional[bool]
             Whether this command's responses should default to ephemeral.
             This will be overridden by any response calls which specify flags.
+
+            Setting this to `None` will let the default set on the parent
+            command(s), component or client propagate and decide the ephemeral
+            default for contexts used by this command.
+
+        Returns
+        -------
+        SelfT
+            This command to allow for chaining.
         """
         self._defaults_to_ephemeral = state
         return self
@@ -928,7 +948,7 @@ class SlashCommandGroup(BaseSlashCommand, abc.SlashCommandGroup):
         /,
         *,
         command_id: typing.Optional[hikari.SnowflakeishOr[hikari.Command]] = None,
-        default_to_ephemeral: bool = False,
+        default_to_ephemeral: typing.Optional[bool] = None,
         default_permission: bool = True,
         is_global: bool = True,
         checks: typing.Optional[collections.Iterable[abc.CheckSig]] = None,
@@ -1098,7 +1118,7 @@ class SlashCommand(BaseSlashCommand, abc.SlashCommand, typing.Generic[CommandCal
         checks: typing.Optional[collections.Iterable[abc.CheckSig]] = None,
         command_id: typing.Optional[hikari.SnowflakeishOr[hikari.Command]] = None,
         default_permission: bool = True,
-        default_to_ephemeral: bool = False,
+        default_to_ephemeral: typing.Optional[bool] = None,
         is_global: bool = True,
         hooks: typing.Optional[abc.SlashHooks] = None,
         metadata: typing.Optional[collections.MutableMapping[typing.Any, typing.Any]] = None,

--- a/tanjun/commands.py
+++ b/tanjun/commands.py
@@ -1089,9 +1089,13 @@ class SlashCommandGroup(BaseSlashCommand, abc.SlashCommandGroup):
         else:
             raise RuntimeError("Missing sub-command option")
 
-        if (command := self._commands.get(option.name)) and await command.check_context(ctx):
-            await command.execute(ctx, option=option, hooks=hooks)
-            return
+        if command := self._commands.get(option.name):
+            if command.defaults_to_ephemeral is not None:
+                ctx.set_ephemeral_default(command.defaults_to_ephemeral)
+
+            if await command.check_context(ctx):
+                await command.execute(ctx, option=option, hooks=hooks)
+                return
 
         await ctx.mark_not_found()
 

--- a/tanjun/context.py
+++ b/tanjun/context.py
@@ -581,7 +581,8 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
         "_has_responded",
         "_interaction",
         "_last_response_id",
-        "_not_found_message",
+        "_marked_not_found",
+        "_on_not_found",
         "_options",
         "_response_future",
         "_response_lock",
@@ -596,7 +597,7 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
         command: typing.Optional[tanjun_abc.BaseSlashCommand] = None,
         component: typing.Optional[tanjun_abc.Component] = None,
         default_to_ephemeral: bool = False,
-        not_found_message: typing.Optional[str] = None,
+        on_not_found: typing.Optional[typing.Callable[[SlashContext], None]] = None,
     ) -> None:
         super().__init__(client, injection_client, component=component)
         self._command = command
@@ -606,7 +607,8 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
         self._has_responded = False
         self._interaction = interaction
         self._last_response_id: typing.Optional[hikari.Snowflake] = None
-        self._not_found_message: typing.Optional[str] = not_found_message
+        self._marked_not_found = False
+        self._on_not_found = on_not_found
         self._response_future: typing.Optional[asyncio.Future[ResponseTypeT]] = None
         self._response_lock = asyncio.Lock()
         self._set_type_special_case(tanjun_abc.SlashContext, self)
@@ -702,28 +704,11 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
 
         return self._response_future
 
-    async def mark_not_found(
-        self, *, flags: typing.Union[hikari.UndefinedType, int, hikari.MessageFlag] = hikari.UNDEFINED
-    ) -> None:
-        flags = flags if flags is not hikari.UNDEFINED else self._get_flags(hikari.UNDEFINED)
-        async with self._response_lock:
-            if self._has_responded or not self._not_found_message:
-                return
+    async def mark_not_found(self) -> None:
 
-            self._has_responded = True
-            if self._has_been_deferred:
-                await self._interaction.edit_initial_response(content=self._not_found_message)
-                return
-
-            if self._response_future:
-                self._response_future.set_result(
-                    self._interaction.build_response().set_flags(flags).set_content(self._not_found_message)
-                )
-
-            else:
-                await self._interaction.create_initial_response(
-                    hikari.ResponseType.MESSAGE_CREATE, content=self._not_found_message, flags=flags
-                )
+        if self._on_not_found and not self._marked_not_found:
+            self._marked_not_found = True
+            await self._on_not_found(self)
 
     def start_defer_timer(self: _SlashContextT, count_down: typing.Union[int, float], /) -> _SlashContextT:
         self._assert_not_final()

--- a/tanjun/context.py
+++ b/tanjun/context.py
@@ -597,7 +597,7 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
         command: typing.Optional[tanjun_abc.BaseSlashCommand] = None,
         component: typing.Optional[tanjun_abc.Component] = None,
         default_to_ephemeral: bool = False,
-        on_not_found: typing.Optional[typing.Callable[[SlashContext], None]] = None,
+        on_not_found: typing.Optional[collections.Callable[[SlashContext], collections.Awaitable[None]]] = None,
     ) -> None:
         super().__init__(client, injection_client, component=component)
         self._command = command
@@ -705,7 +705,6 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
         return self._response_future
 
     async def mark_not_found(self) -> None:
-
         if self._on_not_found and not self._marked_not_found:
             self._marked_not_found = True
             await self._on_not_found(self)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -228,7 +228,7 @@ def test_slash_command_group_with_default():
 
     assert command.tracked_command_id is None
     assert command.build().default_permission is True
-    assert command.defaults_to_ephemeral is False
+    assert command.defaults_to_ephemeral is None
     assert command.is_global is True
     assert isinstance(command, tanjun.SlashCommandGroup)
 
@@ -261,7 +261,7 @@ def test_as_slash_command_with_defaults():
 
     assert command.tracked_command_id is None
     assert command.build().default_permission is hikari.UNDEFINED
-    assert command.defaults_to_ephemeral is False
+    assert command.defaults_to_ephemeral is None
     assert command.is_global is True
     assert command._builder._sort_options is True
     assert isinstance(command, tanjun.SlashCommand)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -212,7 +212,7 @@ class TestPartialCommand:
 
 def test_slash_command_group():
     command = tanjun.slash_command_group(
-        "a_name", "very", default_permission=False, default_to_ephemeral=True, is_global=False
+        "a_name", "very", default_permission=False, defaults_to_ephemeral=True, is_global=False
     )
 
     assert command.name == "a_name"
@@ -240,7 +240,7 @@ def test_as_slash_command():
         "a_very",
         "cool name",
         default_permission=False,
-        default_to_ephemeral=True,
+        defaults_to_ephemeral=True,
         is_global=False,
         sort_options=False,
     )(mock_callback)
@@ -821,7 +821,7 @@ class TestSlashCommandGroup:
 
     @pytest.mark.asyncio()
     async def test_execute(self):
-        mock_command = mock.AsyncMock(set_parent=mock.Mock())
+        mock_command = mock.AsyncMock(set_parent=mock.Mock(), defaults_to_ephemeral=None)
         mock_command.name = "sex"
         mock_command.check_context.return_value = True
         command_group = tanjun.SlashCommandGroup("yee", "nsoosos").add_command(mock_command)
@@ -835,6 +835,25 @@ class TestSlashCommandGroup:
 
         mock_command.execute.assert_awaited_once_with(mock_context, option=mock_option, hooks=mock_hooks)
         mock_command.check_context.assert_awaited_once_with(mock_context)
+        mock_context.set_ephemeral_default.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_execute_when_sub_command_has_ephemeral_default_set(self):
+        mock_command = mock.AsyncMock(set_parent=mock.Mock(), defaults_to_ephemeral=True)
+        mock_command.name = "sex"
+        mock_command.check_context.return_value = True
+        command_group = tanjun.SlashCommandGroup("yee", "nsoosos").add_command(mock_command)
+        mock_context = mock.Mock()
+        mock_option = mock.Mock()
+        mock_option.name = "sex"
+        mock_context.interaction.options = [mock_option]
+        mock_hooks = mock.Mock()
+
+        await command_group.execute(mock_context, hooks=mock_hooks)
+
+        mock_command.execute.assert_awaited_once_with(mock_context, option=mock_option, hooks=mock_hooks)
+        mock_command.check_context.assert_awaited_once_with(mock_context)
+        mock_context.set_ephemeral_default.assert_called_once_with(True)
 
     @pytest.mark.asyncio()
     async def test_execute_when_not_found(self):
@@ -847,10 +866,11 @@ class TestSlashCommandGroup:
         await command_group.execute(mock_context)
 
         mock_context.mark_not_found.assert_awaited_once_with()
+        mock_context.set_ephemeral_default.assert_not_called()
 
     @pytest.mark.asyncio()
     async def test_execute_when_checks_fail(self):
-        mock_command = mock.AsyncMock(set_parent=mock.Mock())
+        mock_command = mock.AsyncMock(set_parent=mock.Mock(), defaults_to_ephemeral=None)
         mock_command.name = "sex"
         mock_command.check_context.return_value = False
         command_group = tanjun.SlashCommandGroup("yee", "nsoosos").add_command(mock_command)
@@ -865,10 +885,13 @@ class TestSlashCommandGroup:
         mock_command.execute.assert_not_called()
         mock_command.check_context.assert_awaited_once_with(mock_context)
         mock_context.mark_not_found.assert_awaited_once_with()
+        mock_context.set_ephemeral_default.assert_not_called()
 
     @pytest.mark.asyncio()
     async def test_execute_when_nested(self):
-        mock_command = mock.AsyncMock(check_context=mock.AsyncMock(return_value=True), set_parent=mock.Mock())
+        mock_command = mock.AsyncMock(
+            check_context=mock.AsyncMock(return_value=True), set_parent=mock.Mock(), defaults_to_ephemeral=None
+        )
         mock_command.name = "hi"
         command_group = tanjun.SlashCommandGroup("yee", "nsoosos").add_command(mock_command)
         mock_context = mock.Mock()
@@ -881,6 +904,7 @@ class TestSlashCommandGroup:
 
         mock_command.execute.assert_awaited_once_with(mock_context, option=mock_sub_option, hooks=mock_hooks)
         mock_command.check_context.assert_awaited_once_with(mock_context)
+        mock_context.set_ephemeral_default.assert_not_called()
 
     @pytest.mark.skip(reason="TODO")
     def test_load_into_component(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -212,7 +212,7 @@ class TestPartialCommand:
 
 def test_slash_command_group():
     command = tanjun.slash_command_group(
-        "a_name", "very", default_permission=False, defaults_to_ephemeral=True, is_global=False
+        "a_name", "very", default_permission=False, default_to_ephemeral=True, is_global=False
     )
 
     assert command.name == "a_name"
@@ -240,7 +240,7 @@ def test_as_slash_command():
         "a_very",
         "cool name",
         default_permission=False,
-        defaults_to_ephemeral=True,
+        default_to_ephemeral=True,
         is_global=False,
         sort_options=False,
     )(mock_callback)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -57,9 +57,17 @@ class TestComponent:
 
         assert component.metadata == {"foo": "bar"}
 
+    def test_defaults_to_ephemeral_property(self):
+        assert tanjun.Component().defaults_to_ephemeral is None
+
     @pytest.mark.skip(reason="TODO")
     def test_copy(self):
         ...
+
+    def test_set_ephemeral_default(self):
+        client = tanjun.Component().set_ephemeral_default(False)
+
+        assert client.defaults_to_ephemeral is False
 
     def test_set_slash_hooks(self):
         mock_hooks = mock.Mock()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1188,7 +1188,6 @@ class TestSlashContext:
 
     @pytest.mark.asyncio()
     async def test_mark_not_found_when_no_callback(self, context: tanjun.SlashContext):
-        on_not_found = mock.AsyncMock()
         context = tanjun.SlashContext(mock.Mock(), mock.Mock(), mock.Mock(options=None), on_not_found=None)
 
         await context.mark_not_found()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -955,7 +955,6 @@ class TestSlashContext:
             mock.AsyncMock(options=None),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
     def test_author_property(self, context: tanjun.SlashContext):
@@ -1001,7 +1000,6 @@ class TestSlashContext:
             mock.Mock(type=hikari.OptionType.SUB_COMMAND, options=raw_options),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         assert context.options == {}
@@ -1017,7 +1015,6 @@ class TestSlashContext:
             mock.Mock(type=hikari.OptionType.SUB_COMMAND, options=[mock_option_1, mock_option_2]),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         assert len(context.options) == 2
@@ -1043,7 +1040,6 @@ class TestSlashContext:
             mock.Mock(type=hikari.OptionType.SUB_COMMAND_GROUP, options=[group_option]),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         assert len(context.options) == 2
@@ -1068,7 +1064,6 @@ class TestSlashContext:
             mock.Mock(type=hikari.OptionType.SUB_COMMAND_GROUP, options=[group_option]),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         assert context.options == {}
@@ -1086,7 +1081,6 @@ class TestSlashContext:
             mock.Mock(type=hikari.OptionType.SUB_COMMAND_GROUP, options=[group_option]),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         assert len(context.options) == 2
@@ -1112,7 +1106,6 @@ class TestSlashContext:
             mock.Mock(type=hikari.OptionType.SUB_COMMAND, options=[group_option]),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         assert context.options == {}
@@ -1126,7 +1119,6 @@ class TestSlashContext:
             mock.Mock(options=None),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         with mock.patch.object(asyncio, "sleep") as sleep:
@@ -1185,99 +1177,32 @@ class TestSlashContext:
             assert result is mock_future
             get_running_loop.assert_not_called()
 
-    @pytest.mark.skip(reason="not implemented")
     @pytest.mark.asyncio()
-    async def test_mark_not_found_with_not_found_message_for_rest_interaction(self, context: tanjun.SlashContext):
-        context._response_future = mock.Mock()
-        context._has_responded = False
-        context._has_been_deferred = False
-        context._not_found_message = "bye"
-
-        await context.mark_not_found(flags=777)
-
-        context._response_future.set_result.assert_called_once_with(
-            context.interaction.build_response().set_flags(777).set_content("bye")
-        )
-        assert isinstance(context.interaction, mock.AsyncMock)
-        context.interaction.create_initial_response.assert_not_called()
-        context.interaction.edit_initial_response.assert_not_called()
-
-    @pytest.mark.asyncio()
-    async def test_mark_not_found_with_not_found_message_for_gateway_interaction(self, context: tanjun.SlashContext):
-        context._has_responded = False
-        context._has_been_deferred = False
-        context._response_future = None
-        context._not_found_message = "hi"
-
-        await context.mark_not_found(flags=555)
-
-        assert isinstance(context.interaction, mock.AsyncMock)
-        context.interaction.create_initial_response.assert_awaited_once_with(
-            hikari.ResponseType.MESSAGE_CREATE, content="hi", flags=555
-        )
-        context.interaction.edit_initial_response.assert_not_called()
-
-    @pytest.mark.asyncio()
-    async def test_mark_not_found_with_not_found_message_when_deferred(self, context: tanjun.SlashContext):
-        context._response_future = mock.Mock()
-        context._has_responded = False
-        context._has_been_deferred = True
-        context._not_found_message = "hi"
+    async def test_mark_not_found(self):
+        on_not_found = mock.AsyncMock()
+        context = tanjun.SlashContext(mock.Mock(), mock.Mock(), mock.Mock(options=None), on_not_found=on_not_found)
 
         await context.mark_not_found()
 
-        context._response_future.set_result.assert_not_called()
-        assert isinstance(context.interaction, mock.AsyncMock)
-        context.interaction.create_initial_response.assert_not_called()
-        context.interaction.edit_initial_response.assert_awaited_once_with(content="hi")
+        on_not_found.assert_awaited_once_with(context)
 
     @pytest.mark.asyncio()
-    async def test_mark_not_found_with_not_found_message_when_already_responded(self, context: tanjun.SlashContext):
-        context._response_future = mock.Mock()
-        context._has_responded = True
-        context._has_been_deferred = False
-        context._not_found_message = "hi"
+    async def test_mark_not_found_when_no_callback(self, context: tanjun.SlashContext):
+        on_not_found = mock.AsyncMock()
+        context = tanjun.SlashContext(mock.Mock(), mock.Mock(), mock.Mock(options=None), on_not_found=None)
 
         await context.mark_not_found()
 
-        context._response_future.set_result.assert_not_called()
-        assert isinstance(context.interaction, mock.AsyncMock)
-        context.interaction.create_initial_response.assert_not_called()
-        context.interaction.edit_initial_response.assert_not_called()
-
     @pytest.mark.asyncio()
-    async def test_mark_not_found_with_not_found_message_no_message(self, context: tanjun.SlashContext):
-        context._response_future = mock.Mock()
-        context._has_responded = False
-        context._has_been_deferred = False
-        context._not_found_message = None
+    async def test_mark_not_found_when_already_marked_as_not_found(self, context: tanjun.SlashContext):
+        on_not_found = mock.AsyncMock()
+        context = tanjun.SlashContext(mock.Mock(), mock.Mock(), mock.Mock(options=None), on_not_found=on_not_found)
+        await context.mark_not_found()
+        on_not_found.reset_mock()
 
         await context.mark_not_found()
 
-        context._response_future.set_result.assert_not_called()
-        assert isinstance(context.interaction, mock.AsyncMock)
-        context.interaction.create_initial_response.assert_not_called()
-        context.interaction.edit_initial_response.assert_not_called()
-
-    @pytest.mark.skip(reason="not implemented")
-    @pytest.mark.parametrize(
-        ("state", "flags"), [(True, hikari.MessageFlag.EPHEMERAL), (False, hikari.MessageFlag.NONE)]
-    )
-    @pytest.mark.asyncio()
-    async def test_mark_not_found_defaults_flags(
-        self, context: tanjun.SlashContext, state: bool, flags: hikari.MessageFlag
-    ):
-        context._response_future = mock.Mock()
-        context._has_responded = False
-        context._has_been_deferred = False
-        context._not_found_message = "bye"
-        context.set_ephemeral_default(state)
-
-        await context.mark_not_found()
-
-        context._response_future.set_result.assert_called_once_with(
-            context.interaction.build_response().set_flags(flags).set_content("bye")
-        )
+        on_not_found.assert_not_called()
 
     def test_start_defer_timer(self, mock_client: mock.Mock):
         auto_defer = mock.Mock()
@@ -1287,7 +1212,6 @@ class TestSlashContext:
             mock.Mock(options=None),
             command=mock.Mock(),
             component=mock.Mock(),
-            not_found_message="hi",
         )
 
         with mock.patch.object(asyncio, "create_task") as create_task:


### PR DESCRIPTION
### Summary
Ephemeral default now propagates from parent entities

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
