### PR TITLE
Switch over to taking a Mapping for slash option choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SlashCommand's ephemeral default now defaults to `None` indicating that the parent entity's state should
   be used.
 
+### Deprecated
+- Passing Iterable[tuple[str, value]] as choices to the slash command options has been deprecated
+  in favour of Mapping[str, value].
+
 ### Removed
 - `tanjun.abc.ExecutableCommand.execute` and `check_context` as this doesn't work typing wise.
   This doesn't effect the implementations nor full command types.

--- a/tanjun/commands.py
+++ b/tanjun/commands.py
@@ -1308,7 +1308,7 @@ class SlashCommand(BaseSlashCommand, abc.SlashCommand, typing.Generic[CommandCal
         choices : typing.Union[collections.abc.Mapping[str, str], collections.abc.Sequence[str], None]
             The option's choices.
 
-            This a mapping of [option_name, option_value] where both option_name
+            This either a mapping of [option_name, option_value] where both option_name
             and option_value should be strings of up to 100 characters or a sequence
             of strings where the string will be used for both the choice's name and
             value.


### PR DESCRIPTION
### Summary
Switch over to taking a Mapping for slash option choices.
While iterable still works for this, they've been deprecated and removed from the type hints

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
